### PR TITLE
Fix min/max search for zero values

### DIFF
--- a/src/main/java/com/hastobe/transparenzsoftware/verification/xml/Meter.java
+++ b/src/main/java/com/hastobe/transparenzsoftware/verification/xml/Meter.java
@@ -91,8 +91,8 @@ public class Meter {
     }
 
     private static double[] getMinMax(List<Meter> values) {
-        double minimum = Double.MAX_VALUE;
-        double max = Double.MIN_VALUE;
+        double minimum = Double.POSITIVE_INFINITY;
+        double max = Double.NEGATIVE_INFINITY;
         boolean startMarkerFound = false;
         boolean stopMarkerFound = false;
         for (Meter meter : values) {


### PR DESCRIPTION
Validating OCMF data with no energy consuption and a reading value of zero will fail with the error message _Stop value is less than start value_.

This is caused by the initial values used for the min/max search. `Double.MIN_VALUE` is actually the smallest positive value which would result in a start value greater than zero. Initializing `max` to `-Double.MAX_VALUE` would solve this issue. But what about using the less misleading infinity constants here? They are larger in magnitude than any finite values.