### PR TITLE
bump allowed ocmf format version

### DIFF
--- a/src/main/java/de/safe_ev/transparenzsoftware/verification/format/ocmf/OCMFVerificationParser.java
+++ b/src/main/java/de/safe_ev/transparenzsoftware/verification/format/ocmf/OCMFVerificationParser.java
@@ -23,7 +23,7 @@ public class OCMFVerificationParser implements VerificationParser {
 	public static final String HEADER_VALUE = "OCMF";
 
 	public static final double MIN_VERSION = 0.1;
-	public static final double MAX_VERSION = 1.1;
+	public static final double MAX_VERSION = 1.2;
 
 	@Override
 	public VerificationType getVerificationType() {


### PR DESCRIPTION
The current ocmf format version (FV:1.2) cannot be verified. Transparenzsoftware needs a version bump (at least) here.
![Screenshot 2024-01-29 114322](https://github.com/SAFE-eV/transparenzsoftware/assets/32635076/4d633280-816e-4fa0-9024-d3350b4dfc71)
