### PR TITLE
Enable actual OCMF 1.4 parsing

### DIFF
--- a/src/main/java/de/safe_ev/transparenzsoftware/verification/format/ocmf/OCMFVerificationParser.java
+++ b/src/main/java/de/safe_ev/transparenzsoftware/verification/format/ocmf/OCMFVerificationParser.java
@@ -23,7 +23,7 @@ public class OCMFVerificationParser implements VerificationParser {
     public static final String HEADER_VALUE = "OCMF";
 
     public static final double MIN_VERSION = 0.1;
-    public static final double MAX_VERSION = 1.4 + 0.1; // must be one more
+    public static final double MAX_VERSION = 1.4;
 
     @Override
     public VerificationType getVerificationType() {
@@ -125,7 +125,7 @@ public class OCMFVerificationParser implements VerificationParser {
 		    "error.ocmf.invalid.version");
 	}
 
-	if (MIN_VERSION > version || MAX_VERSION < version) {
+	if (MIN_VERSION > version || version > MAX_VERSION) {
 	    throw new OCMFValidationException(
 		    String.format("Not compatible with OCMF version %s", simpleData.get("FV").toString()),
 		    "error.ocmf.invalid.version");
@@ -134,12 +134,10 @@ public class OCMFVerificationParser implements VerificationParser {
 	if (version < 0.5) {
 	    ocmfPayloadData = gson.fromJson(rawData,
 		    de.safe_ev.transparenzsoftware.verification.format.ocmf.v02.OCMFPayloadData.class);
-	} else if (version <= 1.3) {
+	}
+	else {
 	    ocmfPayloadData = gson.fromJson(rawData,
 		    de.safe_ev.transparenzsoftware.verification.format.ocmf.v05.OCMFPayloadData.class);
-	} else {
-	    throw new OCMFValidationException(String.format("Not compatible with OCMF version %s", version),
-		    "error.ocmf.invalid.version");
 	}
 	final OCMFSignature signature = gson.fromJson(splittedData[2], OCMFSignature.class);
 


### PR DESCRIPTION
The MAX_VERSION gated versions up to 1.4, but the actual parsing was hard coded to 1.3

Changed version comparison to use MAX_VERSION and removed cutoff logic as the
initial version check now already prevents unsupported versions to pass.